### PR TITLE
Address warnings

### DIFF
--- a/quail/processes/wps_climdex_get_available_indices.py
+++ b/quail/processes/wps_climdex_get_available_indices.py
@@ -64,7 +64,7 @@ class GetIndices(Process):
         mention available indices (values) in their docstrings
         """
         processes = collections.defaultdict(list)
-        indices = re.compile("climdex\.([a-zA-Z0-9]*)")
+        indices = re.compile(r"climdex\.([a-zA-Z0-9]*)")
 
         for mod in [
             module

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,4 @@ click
 psutil
 rpy2==3.3.6
 nchelpers==5.5.7
-wps_tools==1.0.1
-
+wps_tools==1.0.2

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,7 +6,7 @@ pytest-notebook
 nbsphinx
 nbval>=0.9.6
 nbconvert
-sphinx>=1.7
+Sphinx==2.4.4
 bumpversion
 twine
 cruft


### PR DESCRIPTION
Resolves #74 
- Adds r' prefix to regex
```
/tmp/quail-venv/lib/python3.8/site-packages/pywps/inout/basic.py:889: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
    LOGGER.warn("Could not link file reference")
```
[Most recent version](https://github.com/geopython/pywps/blob/20e1e254a3f7914e555fa89f363d1f6eb5f3895c/pywps/inout/basic.py#L892) of pyWPS still uses warn