### PR TITLE
wps-tools 1.2.0 update

### DIFF
--- a/quail/processes/wps_climdexInput_csv.py
+++ b/quail/processes/wps_climdexInput_csv.py
@@ -7,8 +7,13 @@ from pywps.app.exceptions import ProcessError
 
 from wps_tools.logging import log_handler, common_status_percentages
 from wps_tools.io import log_level, collect_args, rda_output, vector_name
-from wps_tools.R import get_package, load_rdata_to_python, save_python_to_rdata
-from quail.utils import logger, collect_literal_inputs, r_valid_name, validate_vector
+from wps_tools.R import (
+    get_package,
+    load_rdata_to_python,
+    save_python_to_rdata,
+    r_valid_name,
+)
+from quail.utils import logger, collect_literal_inputs, validate_vector
 from quail.io import (
     tmax_column,
     tmin_column,

--- a/quail/processes/wps_climdexInput_raw.py
+++ b/quail/processes/wps_climdexInput_raw.py
@@ -17,7 +17,6 @@ from wps_tools.R import (
 from quail.utils import (
     logger,
     collect_literal_inputs,
-    load_rda,
     validate_vector,
 )
 from quail.io import (
@@ -166,7 +165,7 @@ class ClimdexInputRaw(Process):
     def generate_dates(
         self, request, filename, obj_name, date_fields, date_format, cal
     ):
-        load_rda(filename, obj_name)
+        load_rdata_to_python(filename, obj_name)
         try:
             return robjects.r(
                 f"as.PCICt(do.call(paste, {obj_name}[,{date_fields}]), format='{date_format}', cal='{cal}')"

--- a/quail/processes/wps_climdexInput_raw.py
+++ b/quail/processes/wps_climdexInput_raw.py
@@ -8,12 +8,16 @@ from rpy2.rinterface_lib.embedded import RRuntimeError
 
 from wps_tools.logging import log_handler, common_status_percentages
 from wps_tools.io import log_level, collect_args, rda_output, vector_name
-from wps_tools.R import get_package, load_rdata_to_python, save_python_to_rdata
+from wps_tools.R import (
+    get_package,
+    load_rdata_to_python,
+    save_python_to_rdata,
+    r_valid_name,
+)
 from quail.utils import (
     logger,
     collect_literal_inputs,
     load_rda,
-    r_valid_name,
     validate_vector,
 )
 from quail.io import (

--- a/quail/processes/wps_climdex_days.py
+++ b/quail/processes/wps_climdex_days.py
@@ -7,8 +7,8 @@ from pywps.app.Common import Metadata
 
 from wps_tools.logging import log_handler, common_status_percentages
 from wps_tools.io import log_level, collect_args, rda_output, vector_name
-from wps_tools.R import get_package, save_python_to_rdata
-from quail.utils import logger, load_ci, r_valid_name
+from wps_tools.R import get_package, save_python_to_rdata, r_valid_name
+from quail.utils import logger, load_ci
 from quail.io import climdex_input, ci_name, output_file
 
 

--- a/quail/processes/wps_climdex_dtr.py
+++ b/quail/processes/wps_climdex_dtr.py
@@ -7,8 +7,8 @@ from pywps.app.Common import Metadata
 
 from wps_tools.logging import log_handler, common_status_percentages
 from wps_tools.io import log_level, collect_args, rda_output, vector_name
-from wps_tools.R import get_package, save_python_to_rdata
-from quail.utils import logger, load_ci, r_valid_name
+from wps_tools.R import get_package, save_python_to_rdata, r_valid_name
+from quail.utils import logger, load_ci
 from quail.io import climdex_input, ci_name, output_file, freq
 
 

--- a/quail/processes/wps_climdex_gsl.py
+++ b/quail/processes/wps_climdex_gsl.py
@@ -8,8 +8,13 @@ from rpy2.rinterface_lib.embedded import RRuntimeError
 
 from wps_tools.logging import log_handler, common_status_percentages
 from wps_tools.io import log_level, collect_args, rda_output, vector_name
-from wps_tools.R import get_package, load_rdata_to_python, save_python_to_rdata
-from quail.utils import logger, load_ci, r_valid_name
+from wps_tools.R import (
+    get_package,
+    load_rdata_to_python,
+    save_python_to_rdata,
+    r_valid_name,
+)
+from quail.utils import logger, load_ci
 from quail.io import climdex_input, ci_name, output_file
 
 

--- a/quail/processes/wps_climdex_mmdmt.py
+++ b/quail/processes/wps_climdex_mmdmt.py
@@ -7,8 +7,13 @@ from rpy2.rinterface_lib.embedded import RRuntimeError
 
 from wps_tools.logging import log_handler, common_status_percentages
 from wps_tools.io import log_level, collect_args, rda_output, vector_name
-from wps_tools.R import get_package, load_rdata_to_python, save_python_to_rdata
-from quail.utils import logger, load_ci, r_valid_name
+from wps_tools.R import (
+    get_package,
+    load_rdata_to_python,
+    save_python_to_rdata,
+    r_valid_name,
+)
+from quail.utils import logger, load_ci
 from quail.io import climdex_input, ci_name, output_file, freq
 
 

--- a/quail/processes/wps_climdex_ptot.py
+++ b/quail/processes/wps_climdex_ptot.py
@@ -7,8 +7,13 @@ from rpy2.rinterface_lib.embedded import RRuntimeError
 
 from wps_tools.logging import log_handler, common_status_percentages
 from wps_tools.io import log_level, collect_args, rda_output, vector_name
-from wps_tools.R import get_package, load_rdata_to_python, save_python_to_rdata
-from quail.utils import logger, load_ci, r_valid_name
+from wps_tools.R import (
+    get_package,
+    load_rdata_to_python,
+    save_python_to_rdata,
+    r_valid_name,
+)
+from quail.utils import logger, load_ci
 from quail.io import climdex_input, ci_name, output_file
 
 

--- a/quail/processes/wps_climdex_quantile.py
+++ b/quail/processes/wps_climdex_quantile.py
@@ -7,8 +7,13 @@ from rpy2.rinterface_lib.embedded import RRuntimeError
 
 from wps_tools.logging import log_handler, common_status_percentages
 from wps_tools.io import log_level, collect_args, rda_output, vector_name
-from wps_tools.R import get_package, load_rdata_to_python, save_python_to_rdata
-from quail.utils import logger, collect_literal_inputs, load_rda, r_valid_name
+from wps_tools.R import (
+    get_package,
+    load_rdata_to_python,
+    save_python_to_rdata,
+    r_valid_name,
+)
+from quail.utils import logger, collect_literal_inputs, load_rda, validate_vector
 from quail.io import output_file
 
 
@@ -104,6 +109,7 @@ class ClimdexQuantile(Process):
             vector_name,
             loglevel,
         ) = self.collect_args_wrapper(request)
+        validate_vector(quantiles_vector)
         r_valid_name(vector_name)
 
         log_handler(

--- a/quail/processes/wps_climdex_quantile.py
+++ b/quail/processes/wps_climdex_quantile.py
@@ -13,7 +13,7 @@ from wps_tools.R import (
     save_python_to_rdata,
     r_valid_name,
 )
-from quail.utils import logger, collect_literal_inputs, load_rda, validate_vector
+from quail.utils import logger, collect_literal_inputs, validate_vector
 from quail.io import output_file
 
 
@@ -132,7 +132,7 @@ class ClimdexQuantile(Process):
         )
 
         if data_file:
-            data = load_rda(data_file, data_vector)
+            data = load_rdata_to_python(data_file, data_vector)
         else:
             data = robjects.r(data_vector)
 

--- a/quail/processes/wps_climdex_rmm.py
+++ b/quail/processes/wps_climdex_rmm.py
@@ -7,8 +7,13 @@ from pywps.app.Common import Metadata
 
 from wps_tools.logging import log_handler, common_status_percentages
 from wps_tools.io import log_level, collect_args, rda_output, vector_name
-from wps_tools.R import get_package, load_rdata_to_python, save_python_to_rdata
-from quail.utils import logger, load_ci, r_valid_name
+from wps_tools.R import (
+    get_package,
+    load_rdata_to_python,
+    save_python_to_rdata,
+    r_valid_name,
+)
+from quail.utils import logger, load_ci
 from quail.io import climdex_input, ci_name, output_file
 
 

--- a/quail/processes/wps_climdex_rxnday.py
+++ b/quail/processes/wps_climdex_rxnday.py
@@ -7,8 +7,13 @@ from rpy2.rinterface_lib.embedded import RRuntimeError
 
 from wps_tools.logging import log_handler, common_status_percentages
 from wps_tools.io import log_level, collect_args, rda_output, vector_name
-from wps_tools.R import get_package, load_rdata_to_python, save_python_to_rdata
-from quail.utils import logger, load_ci, r_valid_name
+from wps_tools.R import (
+    get_package,
+    load_rdata_to_python,
+    save_python_to_rdata,
+    r_valid_name,
+)
+from quail.utils import logger, load_ci
 from quail.io import climdex_input, ci_name, output_file, freq
 
 

--- a/quail/processes/wps_climdex_sdii.py
+++ b/quail/processes/wps_climdex_sdii.py
@@ -7,8 +7,13 @@ from rpy2.rinterface_lib.embedded import RRuntimeError
 
 from wps_tools.logging import log_handler, common_status_percentages
 from wps_tools.io import log_level, collect_args, rda_output, vector_name
-from wps_tools.R import get_package, load_rdata_to_python, save_python_to_rdata
-from quail.utils import logger, load_ci, r_valid_name
+from wps_tools.R import (
+    get_package,
+    load_rdata_to_python,
+    save_python_to_rdata,
+    r_valid_name,
+)
+from quail.utils import logger, load_ci
 from quail.io import climdex_input, ci_name, output_file
 
 

--- a/quail/processes/wps_climdex_spells.py
+++ b/quail/processes/wps_climdex_spells.py
@@ -8,8 +8,13 @@ from pywps.app.exceptions import ProcessError
 
 from wps_tools.logging import log_handler, common_status_percentages
 from wps_tools.io import log_level, collect_args, rda_output, vector_name
-from wps_tools.R import get_package, load_rdata_to_python, save_python_to_rdata
-from quail.utils import logger, load_ci, r_valid_name
+from wps_tools.R import (
+    get_package,
+    load_rdata_to_python,
+    save_python_to_rdata,
+    r_valid_name,
+)
+from quail.utils import logger, load_ci
 from quail.io import climdex_input, ci_name, output_file
 
 

--- a/quail/processes/wps_climdex_temp_pctl.py
+++ b/quail/processes/wps_climdex_temp_pctl.py
@@ -7,8 +7,13 @@ from rpy2.rinterface_lib.embedded import RRuntimeError
 
 from wps_tools.logging import log_handler, common_status_percentages
 from wps_tools.io import log_level, collect_args, rda_output, vector_name
-from wps_tools.R import get_package, load_rdata_to_python, save_python_to_rdata
-from quail.utils import logger, load_ci, r_valid_name
+from wps_tools.R import (
+    get_package,
+    load_rdata_to_python,
+    save_python_to_rdata,
+    r_valid_name,
+)
+from quail.utils import logger, load_ci
 from quail.io import climdex_input, ci_name, output_file, freq
 
 

--- a/quail/utils.py
+++ b/quail/utils.py
@@ -62,7 +62,8 @@ def load_ci(climdex_input, ci_name):
             raise ProcessError(
                 msg="Input for ci-name is not a valid climdexInput object"
             )
-
+    except ProcessError:
+        raise
     except RRuntimeError as e:
         logger.error(f"cannot load {ci_name} from {climdex_input}")
         raise ProcessError(
@@ -83,15 +84,6 @@ def load_rda(file_, obj_name):
             raise ProcessError(
                 msg=f"{type(e).__name__}: There is no object named {err_name[0]} in this rda file"
             )
-
-
-def r_valid_name(robj_name):
-    """The R function 'make.names' will change a name if it
-    is not syntactically correct and leave it if it is
-    """
-    base = get_package("base")
-    if base.make_names(robj_name)[0] != robj_name:
-        raise ProcessError(msg="Your vector name is not a valid R name")
 
 
 # Testing
@@ -143,24 +135,3 @@ def test_ci_output(url, vector_name, expected_file, expected_vector_name):
 
     # Clear R global env
     robjects.r("rm(list=ls())")
-
-
-def process_err_test(process, datainputs, err_type):
-    err = io.StringIO()
-    with redirect_stderr(err):
-        with pytest.raises(Exception):
-            run_wps_process(process(), datainputs)
-
-    if err_type == "unknown ci name":
-        msg = "RRuntimeError: Either your file is not a valid Rdata file or the climdexInput object name is not found in this rda file"
-    elif err_type == "class is not ci":
-        msg = "Input for ci-name is not a valid climdexInput object"
-    elif err_type == "load_rda err":
-        msg = "object"
-    elif err_type == "invalid vector name":
-        msg = "Your vector name is not a valid R name"
-    elif err_type == "bad syntax":
-        msg = "RParsingError: Invalid vector format, follow R vector syntax"
-    elif err_type == "invlaid column":
-        msg = "column of that name"
-    assert msg in err.getvalue()

--- a/quail/utils.py
+++ b/quail/utils.py
@@ -54,36 +54,11 @@ def validate_vector(vector):
 
 
 def load_ci(climdex_input, ci_name):
-    try:
-        ci = load_rdata_to_python(climdex_input, ci_name)
-        if ci.rclass[0] == "climdexInput":
-            return ci
-        else:
-            raise ProcessError(
-                msg="Input for ci-name is not a valid climdexInput object"
-            )
-    except ProcessError:
-        raise
-    except RRuntimeError as e:
-        logger.error(f"cannot load {ci_name} from {climdex_input}")
-        raise ProcessError(
-            msg=f"{type(e).__name__}: Either your file is not a valid Rdata file or the climdexInput object name is not found in this rda file"
-        )
-
-
-def load_rda(file_, obj_name):
-    try:
-        return load_rdata_to_python(file_, obj_name)
-    except RRuntimeError as e:
-        err_name = re.compile(r"object \'(.*)\' not found").findall(str(e))
-        if "_" in err_name[0]:
-            raise ProcessError(
-                msg=f"{type(e).__name__}: One of the variable names passed is not an object found in the given rda files"
-            )
-        else:
-            raise ProcessError(
-                msg=f"{type(e).__name__}: There is no object named {err_name[0]} in this rda file"
-            )
+    ci = load_rdata_to_python(climdex_input, ci_name)
+    if ci.rclass[0] == "climdexInput":
+        return ci
+    else:
+        raise ProcessError(msg="Input for ci-name is not a valid climdexInput object")
 
 
 # Testing

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ click
 psutil
 rpy2==3.3.6
 nchelpers==5.5.7
-wps_tools==1.0.2
+wps_tools==1.2.0

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,38 +5,38 @@ from pywps.app.exceptions import ProcessError
 from tempfile import NamedTemporaryFile
 from contextlib import redirect_stderr
 
-from quail.utils import load_ci, load_rda, r_valid_name, validate_vector
+from quail.utils import load_ci, load_rda, validate_vector
 from wps_tools.testing import local_path
 
 
 @pytest.mark.parametrize(
     ("file_", "obj_name"),
     [
-        (local_path("expected_days_data.rda"), "summer_days"),
+        (resource_filename("tests", "data/expected_gsl.rda"), "expected_gsl_vector"),
     ],
 )
 def test_load_ci_obj_err(file_, obj_name):
     with pytest.raises(ProcessError) as e:
         load_ci(file_, obj_name)
-        assert (
-            str(vars(e)["_excinfo"][1])
-            == "Input for ci-name is not a valid climdexInput object"
-        )
+    assert (
+        str(vars(e)["_excinfo"][1])
+        == "Input for ci-name is not a valid climdexInput object"
+    )
 
 
 @pytest.mark.parametrize(
     ("file_", "obj_name"),
     [
-        (local_path("climdexInput.rda"), "not_ci"),
+        (resource_filename("tests", "data/climdexInput.rda"), "not_ci"),
     ],
 )
 def test_load_ci_name_err(file_, obj_name):
     with pytest.raises(ProcessError) as e:
         load_ci(file_, obj_name)
-        assert (
-            str(vars(e)["_excinfo"][1])
-            == "Either your file is not a valid Rdata file or the climdexInput object name is not found in this rda file"
-        )
+    assert (
+        str(vars(e)["_excinfo"][1])
+        == "RRuntimeError: The variable name passed is not an object found in the given rda file"
+    )
 
 
 @pytest.mark.parametrize(
@@ -55,16 +55,6 @@ def test_load_rda_err(file_, obj_name):
 
 
 @pytest.mark.parametrize(
-    ("name"),
-    [(".2"), ("if"), ("two words")],
-)
-def test_r_valid_name(name):
-    with pytest.raises(ProcessError) as e:
-        r_valid_name(name)
-        assert str(vars(e)["_excinfo"][1]) == "Your vector name is not a valid R name"
-
-
-@pytest.mark.parametrize(
     ("vector"),
     [("c('cats')"), ("c('cats', 'dogs')"), ("c(cats=1, dogs=2)")],
 )
@@ -73,16 +63,13 @@ def test_validate_vector(vector):
 
 
 @pytest.mark.parametrize(
-    ("vector", "err_type"),
-    [("()", "not vector"), ("c'cats', 'dogs')", "invalid syntax")],
+    ("vector"),
+    [("()"), ("c'cats', 'dogs')")],
 )
-def test_validate_vector_err(vector, err_type):
+def test_validate_vector_err(vector):
     with pytest.raises(ProcessError) as e:
         validate_vector(vector)
-        if err_type == "not vector":
-            assert str(vars(e)["_excinfo"][1]) == "Invalid type passed for vector"
-        if err_type == "invalid syntax":
-            assert (
-                str(vars(e)["_excinfo"][1])
-                == "RRuntimeError: Invalid vector format, follow R vector syntax"
-            )
+    assert (
+        str(vars(e)["_excinfo"][1])
+        == "RParsingError: Invalid vector format, follow R vector syntax"
+    )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,7 +5,7 @@ from pywps.app.exceptions import ProcessError
 from tempfile import NamedTemporaryFile
 from contextlib import redirect_stderr
 
-from quail.utils import load_ci, load_rda, validate_vector
+from quail.utils import load_ci, validate_vector
 from wps_tools.testing import local_path
 
 
@@ -37,21 +37,6 @@ def test_load_ci_name_err(file_, obj_name):
         str(vars(e)["_excinfo"][1])
         == "RRuntimeError: The variable name passed is not an object found in the given rda file"
     )
-
-
-@pytest.mark.parametrize(
-    ("file_", "obj_name"),
-    [
-        (resource_filename("tests", "data/expected_days_data.rda"), "autumn_days"),
-    ],
-)
-def test_load_rda_err(file_, obj_name):
-    with pytest.raises(ProcessError) as e:
-        load_rda(file_, obj_name)
-        assert (
-            str(vars(e)["_excinfo"][1])
-            == "RRuntimeError: One of the variable names passed is not an object found in the given rda files"
-        )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_wps_climdexInput_csv.py
+++ b/tests/test_wps_climdexInput_csv.py
@@ -1,9 +1,32 @@
 import pytest
 from tempfile import NamedTemporaryFile
 
-from wps_tools.testing import run_wps_process, local_path
+from wps_tools.testing import run_wps_process, local_path, process_err_test
 from quail.processes.wps_climdexInput_csv import ClimdexInputCSV
-from quail.utils import process_err_test
+
+
+def build_params(
+    tmax_file,
+    tmin_file,
+    prec_file,
+    tmax_column,
+    tmin_column,
+    prec_column,
+    base_range,
+    vector_name,
+    output_file,
+):
+    return (
+        f"tmax_file=@xlink:href={tmax_file};"
+        f"tmin_file=@xlink:href={tmin_file};"
+        f"prec_file=@xlink:href={prec_file};"
+        f"tmax_column={tmax_column};"
+        f"tmin_column={tmin_column};"
+        f"prec_column={prec_column};"
+        f"base_range={base_range};"
+        f"out_file={output_file};"
+        f"vector_name={vector_name};"
+    )
 
 
 @pytest.mark.parametrize(
@@ -43,16 +66,16 @@ def test_wps_climdexInput_csv(
     with NamedTemporaryFile(
         suffix=".rda", prefix="output_", dir="/tmp", delete=True
     ) as out_file:
-        datainputs = (
-            f"tmax_file=@xlink:href={tmax_file};"
-            f"tmin_file=@xlink:href={tmin_file};"
-            f"prec_file=@xlink:href={prec_file};"
-            f"tmax_column={tmax_column};"
-            f"tmin_column={tmin_column};"
-            f"prec_column={prec_column};"
-            f"base_range={base_range};"
-            f"out_file={out_file.name};"
-            f"vector_name={vector_name};"
+        datainputs = build_params(
+            tmax_file,
+            tmin_file,
+            prec_file,
+            tmax_column,
+            tmin_column,
+            prec_column,
+            base_range,
+            vector_name,
+            out_file.name,
         )
         run_wps_process(ClimdexInputCSV(), datainputs)
 
@@ -67,7 +90,6 @@ def test_wps_climdexInput_csv(
         "prec_column",
         "base_range",
         "vector_name",
-        "err_type",
     ),
     [
         (
@@ -79,8 +101,48 @@ def test_wps_climdexInput_csv(
             "ONE_DAY_PRECIPITATION",
             "c(1971, 2000)",
             "climdexInput",
-            "invlaid column",
         ),
+    ],
+)
+def test_wps_climdexInput_csv_column_err(
+    tmax_file,
+    tmin_file,
+    prec_file,
+    tmax_column,
+    tmin_column,
+    prec_column,
+    base_range,
+    vector_name,
+):
+    with NamedTemporaryFile(
+        suffix=".rda", prefix="output_", dir="/tmp", delete=True
+    ) as out_file:
+        datainputs = build_params(
+            tmax_file,
+            tmin_file,
+            prec_file,
+            tmax_column,
+            tmin_column,
+            prec_column,
+            base_range,
+            vector_name,
+            out_file.name,
+        )
+        process_err_test(ClimdexInputCSV, datainputs)
+
+
+@pytest.mark.parametrize(
+    (
+        "tmax_file",
+        "tmin_file",
+        "prec_file",
+        "tmax_column",
+        "tmin_column",
+        "prec_column",
+        "base_range",
+        "vector_name",
+    ),
+    [
         (
             local_path("1018935_MAX_TEMP.csv"),
             local_path("1018935_MIN_TEMP.csv"),
@@ -90,11 +152,10 @@ def test_wps_climdexInput_csv(
             "ONE_DAY_PRECIPITATION",
             "c1971, 2000)",
             "climdexInput",
-            "bad syntax",
         ),
     ],
 )
-def test_wps_climdexInput_csv_err(
+def test_wps_climdexInput_csv_syntax_err(
     tmax_file,
     tmin_file,
     prec_file,
@@ -103,20 +164,19 @@ def test_wps_climdexInput_csv_err(
     prec_column,
     base_range,
     vector_name,
-    err_type,
 ):
     with NamedTemporaryFile(
         suffix=".rda", prefix="output_", dir="/tmp", delete=True
     ) as out_file:
-        datainputs = (
-            f"tmax_file=@xlink:href={tmax_file};"
-            f"tmin_file=@xlink:href={tmin_file};"
-            f"prec_file=@xlink:href={prec_file};"
-            f"tmax_column={tmax_column};"
-            f"tmin_column={tmin_column};"
-            f"prec_column={prec_column};"
-            f"base_range={base_range};"
-            f"out_file={out_file.name};"
-            f"vector_name={vector_name};"
+        datainputs = build_params(
+            tmax_file,
+            tmin_file,
+            prec_file,
+            tmax_column,
+            tmin_column,
+            prec_column,
+            base_range,
+            vector_name,
+            out_file.name,
         )
-        process_err_test(ClimdexInputCSV, datainputs, err_type)
+        process_err_test(ClimdexInputCSV, datainputs)

--- a/tests/test_wps_climdexInput_raw.py
+++ b/tests/test_wps_climdexInput_raw.py
@@ -1,9 +1,8 @@
 import pytest
 from tempfile import NamedTemporaryFile
 
-from wps_tools.testing import run_wps_process, local_path
+from wps_tools.testing import run_wps_process, local_path, process_err_test
 from quail.processes.wps_climdexInput_raw import ClimdexInputRaw
-from quail.utils import process_err_test
 
 
 @pytest.mark.parametrize(
@@ -82,7 +81,6 @@ def test_wps_climdexInput_raw(
         "prec_column",
         "base_range",
         "vector_name",
-        "err_type",
     ),
     [
         (
@@ -97,7 +95,6 @@ def test_wps_climdexInput_raw(
             "ONE_DAY_PRECIPITATION",
             "c(1971, 2000)",
             "climdexInput",
-            "load_rda err",
         ),
         (
             local_path("ec.1018935.rda"),
@@ -111,7 +108,6 @@ def test_wps_climdexInput_raw(
             "ONE_DAY_PRECIPITATION",
             "c(1971, 2000)",
             "climdex Input",
-            "invalid vector name",
         ),
         (
             local_path("ec.1018935.rda"),
@@ -125,7 +121,6 @@ def test_wps_climdexInput_raw(
             "ONE_DAY_PRECIPITATION",
             "c(1971, 2000)",
             "climdexInput",
-            "invlaid column",
         ),
         (
             local_path("ec.1018935.rda"),
@@ -139,7 +134,6 @@ def test_wps_climdexInput_raw(
             "ONE_DAY_PRECIPITATION",
             "c1971, 2000)",
             "climdexInput",
-            "bad syntax",
         ),
     ],
 )
@@ -155,7 +149,6 @@ def test_wps_climdexInput_raw_err(
     prec_column,
     base_range,
     vector_name,
-    err_type,
 ):
     with NamedTemporaryFile(
         suffix=".rda", prefix="output_", dir="/tmp", delete=True
@@ -174,4 +167,4 @@ def test_wps_climdexInput_raw_err(
             f"out_file={out_file.name};"
             f"vector_name={vector_name};"
         )
-        process_err_test(ClimdexInputRaw, datainputs, err_type)
+        process_err_test(ClimdexInputRaw, datainputs)

--- a/tests/test_wps_climdex_dtr.py
+++ b/tests/test_wps_climdex_dtr.py
@@ -3,66 +3,80 @@ import io
 from tempfile import NamedTemporaryFile
 from contextlib import redirect_stderr
 
-from wps_tools.testing import run_wps_process, local_path
+from wps_tools.testing import run_wps_process, local_path, process_err_test
 from quail.processes.wps_climdex_dtr import ClimdexDTR
-from quail.utils import process_err_test
+
+
+def build_params(climdex_input, ci_name, freq, vector_name, output_file):
+    return (
+        f"climdex_input=@xlink:href={climdex_input};"
+        f"ci_name={ci_name};"
+        f"vector_name={vector_name};"
+        f"freq={freq};"
+        f"output_file={output_file};"
+    )
 
 
 @pytest.mark.parametrize(
-    ("climdex_input", "ci_name", "freq"),
+    ("climdex_input", "ci_name", "freq", "vector_name"),
     [
-        (local_path("climdexInput.rda"), "ci", "monthly"),
-        (local_path("climdexInput.rda"), "ci", "annual"),
+        (local_path("climdexInput.rda"), "ci", "monthly", "dtr"),
+        (local_path("climdexInput.rda"), "ci", "annual", "dtr"),
     ],
 )
-def test_wps_climdex_dtr(climdex_input, ci_name, freq):
+def test_wps_climdex_dtr(climdex_input, ci_name, freq, vector_name):
     with NamedTemporaryFile(
         suffix=".rda", prefix="output_", dir="/tmp", delete=True
     ) as out_file:
-        datainputs = (
-            f"climdex_input=@xlink:href={climdex_input};"
-            f"ci_name={ci_name};"
-            f"freq={freq};"
-            f"output_file={out_file.name};"
+        datainputs = build_params(
+            climdex_input, ci_name, freq, vector_name, out_file.name
         )
         run_wps_process(ClimdexDTR(), datainputs)
 
 
 @pytest.mark.parametrize(
-    ("climdex_input", "ci_name", "freq", "vector_name", "err_type"),
+    ("climdex_input", "ci_name", "freq", "vector_name"),
+    [
+        (
+            local_path("climdexInput.rda"),
+            "ci",
+            "monthly",
+            "vector name",
+        ),
+    ],
+)
+def test_wps_climdex_dtr_vector_err(climdex_input, ci_name, freq, vector_name):
+    with NamedTemporaryFile(
+        suffix=".rda", prefix="output_", dir="/tmp", delete=True
+    ) as out_file:
+        datainputs = build_params(
+            climdex_input, ci_name, freq, vector_name, out_file.name
+        )
+        process_err_test(ClimdexDTR, datainputs)
+
+
+@pytest.mark.parametrize(
+    ("climdex_input", "ci_name", "freq", "vector_name"),
     [
         (
             local_path("climdexInput.rda"),
             "not_ci",
             "monthly",
             "vector_name",
-            "unknown ci name",
-        ),
-        (
-            local_path("climdexInput.rda"),
-            "ci",
-            "monthly",
-            "vector name",
-            "invalid vector name",
         ),
         (
             local_path("expected_dtr.rda"),
             "expected_dtr_annual",
             "annual",
             "vector_name",
-            "class is not ci",
         ),
     ],
 )
-def test_wps_climdex_dtr_err(climdex_input, ci_name, freq, err_type, vector_name):
+def test_wps_climdex_dtr_ci_err(climdex_input, ci_name, freq, vector_name):
     with NamedTemporaryFile(
         suffix=".rda", prefix="output_", dir="/tmp", delete=True
     ) as out_file:
-        datainputs = (
-            f"climdex_input=@xlink:href={climdex_input};"
-            f"ci_name={ci_name};"
-            f"vector_name={vector_name};"
-            f"freq={freq};"
-            f"output_file={out_file.name};"
+        datainputs = build_params(
+            climdex_input, ci_name, freq, vector_name, out_file.name
         )
-        process_err_test(ClimdexDTR, datainputs, err_type)
+        process_err_test(ClimdexDTR, datainputs)

--- a/tests/test_wps_climdex_get_available_indices.py
+++ b/tests/test_wps_climdex_get_available_indices.py
@@ -4,9 +4,8 @@ from rpy2 import robjects
 from itertools import chain
 from tempfile import NamedTemporaryFile
 
-from wps_tools.testing import run_wps_process, local_path
+from wps_tools.testing import run_wps_process, local_path, process_err_test
 from quail.processes.wps_climdex_get_available_indices import GetIndices
-from quail.utils import process_err_test
 
 
 @pytest.mark.parametrize(
@@ -26,13 +25,13 @@ def test_wps_get_available_indices(climdex_input, ci_name):
 
 
 @pytest.mark.parametrize(
-    ("climdex_input", "ci_name", "err_type"),
+    ("climdex_input", "ci_name"),
     [
-        (local_path("climdexInput.rda"), "not_ci", "unknown ci name"),
-        (local_path("expected_dtr.rda"), "expected_dtr_annual", "class is not ci"),
+        (local_path("climdexInput.rda"), "not_ci"),
+        (local_path("expected_dtr.rda"), "expected_dtr_annual"),
     ],
 )
-def test_wps_get_available_indices_err(climdex_input, ci_name, err_type):
+def test_wps_get_available_indices_ci_err(climdex_input, ci_name):
     with NamedTemporaryFile(
         suffix=".rda", prefix="output_", dir="/tmp", delete=True
     ) as out_file:
@@ -41,7 +40,7 @@ def test_wps_get_available_indices_err(climdex_input, ci_name, err_type):
             f"ci_name={ci_name};"
             f"output_file={out_file.name};"
         )
-        process_err_test(GetIndices, datainputs, err_type)
+        process_err_test(GetIndices, datainputs)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_wps_climdex_gsl.py
+++ b/tests/test_wps_climdex_gsl.py
@@ -1,84 +1,102 @@
 import pytest
 from tempfile import NamedTemporaryFile
 
-from wps_tools.testing import run_wps_process, local_path
+from wps_tools.testing import run_wps_process, local_path, process_err_test
 from quail.processes.wps_climdex_gsl import ClimdexGSL
-from quail.utils import process_err_test
+
+
+def build_params(climdex_input, ci_name, vector_name, gsl_mode, output_file):
+    return (
+        f"climdex_input=@xlink:href={climdex_input};"
+        f"ci_name={ci_name};"
+        f"vector_name={vector_name};"
+        f"gsl_mode={gsl_mode};"
+        f"output_file={output_file};"
+    )
 
 
 @pytest.mark.parametrize(
-    ("climdex_input", "ci_name", "gsl_mode"),
+    ("climdex_input", "ci_name", "vector_name", "gsl_mode"),
     [
         (
             local_path("climdexInput.rda"),
             "ci",
+            "vector_name",
             "GSL",
         ),
         (
             local_path("climdexInput.rda"),
             "ci",
+            "vector_name",
             "GSL_first",
         ),
         (
             local_path("climdexInput.rda"),
             "ci",
+            "vector_name",
             "GSL_max",
         ),
         (
             local_path("climdexInput.rda"),
             "ci",
+            "vector_name",
             "GSL_sum",
         ),
     ],
 )
-def test_wps_climdex_gsl(climdex_input, ci_name, gsl_mode):
+def test_wps_climdex_gsl(climdex_input, ci_name, vector_name, gsl_mode):
     with NamedTemporaryFile(
         suffix=".rda", prefix="output_", dir="/tmp", delete=True
     ) as out_file:
-        datainputs = (
-            f"climdex_input=@xlink:href={climdex_input};"
-            f"ci_name={ci_name};"
-            f"gsl_mode={gsl_mode};"
-            f"output_file={out_file.name};"
+        datainputs = build_params(
+            climdex_input, ci_name, vector_name, gsl_mode, out_file.name
         )
         run_wps_process(ClimdexGSL(), datainputs)
 
 
 @pytest.mark.parametrize(
-    ("climdex_input", "ci_name", "gsl_mode", "vector_name", "err_type"),
+    ("climdex_input", "ci_name", "gsl_mode", "vector_name"),
+    [
+        (
+            local_path("climdexInput.rda"),
+            "ci",
+            "GSL",
+            "vector name",
+        ),
+    ],
+)
+def test_wps_climdex_gsl_vector_err(climdex_input, ci_name, gsl_mode, vector_name):
+    with NamedTemporaryFile(
+        suffix=".rda", prefix="output_", dir="/tmp", delete=True
+    ) as out_file:
+        datainputs = build_params(
+            climdex_input, ci_name, vector_name, gsl_mode, out_file.name
+        )
+        process_err_test(ClimdexGSL, datainputs)
+
+
+@pytest.mark.parametrize(
+    ("climdex_input", "ci_name", "gsl_mode", "vector_name"),
     [
         (
             local_path("climdexInput.rda"),
             "not_ci",
             "GSL",
             "vector_name",
-            "unknown ci name",
-        ),
-        (
-            local_path("climdexInput.rda"),
-            "ci",
-            "GSL",
-            "vector name",
-            "invalid vector name",
         ),
         (
             local_path("expected_gsl.rda"),
             "expected_gsl_vector",
             "GSL",
             "vector_name",
-            "class is not ci",
         ),
     ],
 )
-def test_wps_climdex_gsl_err(climdex_input, ci_name, gsl_mode, err_type, vector_name):
+def test_wps_climdex_gsl_ci_err(climdex_input, ci_name, gsl_mode, vector_name):
     with NamedTemporaryFile(
         suffix=".rda", prefix="output_", dir="/tmp", delete=True
     ) as out_file:
-        datainputs = (
-            f"climdex_input=@xlink:href={climdex_input};"
-            f"ci_name={ci_name};"
-            f"vector_name={vector_name};"
-            f"gsl_mode={gsl_mode};"
-            f"output_file={out_file.name};"
+        datainputs = build_params(
+            climdex_input, ci_name, vector_name, gsl_mode, out_file.name
         )
-        process_err_test(ClimdexGSL, datainputs, err_type)
+        process_err_test(ClimdexGSL, datainputs)

--- a/tests/test_wps_climdex_mmdmt.py
+++ b/tests/test_wps_climdex_mmdmt.py
@@ -1,40 +1,70 @@
 import pytest
 from tempfile import NamedTemporaryFile
 
-from wps_tools.testing import run_wps_process, local_path
+from wps_tools.testing import run_wps_process, local_path, process_err_test
 from quail.processes.wps_climdex_mmdmt import ClimdexMMDMT
-from quail.utils import process_err_test
+
+
+def build_params(climdex_input, ci_name, month_type, freq, vector_name, output_file):
+    return (
+        f"climdex_input=@xlink:href={climdex_input};"
+        f"ci_name={ci_name};"
+        f"month_type={month_type};"
+        f"vector_name={vector_name};"
+        f"freq={freq};"
+        f"output_file={output_file};"
+    )
 
 
 @pytest.mark.parametrize(
-    ("climdex_input", "ci_name", "month_type", "freq"),
+    ("climdex_input", "ci_name", "month_type", "freq", "vector_name"),
     [
-        (local_path("climdexInput.rda"), "ci", "txx", "monthly"),
-        (local_path("climdexInput.rda"), "ci", "txx", "annual"),
-        (local_path("climdexInput.rda"), "ci", "tnx", "monthly"),
-        (local_path("climdexInput.rda"), "ci", "tnx", "annual"),
-        (local_path("climdexInput.rda"), "ci", "txn", "monthly"),
-        (local_path("climdexInput.rda"), "ci", "txn", "annual"),
-        (local_path("climdexInput.rda"), "ci", "tnn", "monthly"),
-        (local_path("climdexInput.rda"), "ci", "tnn", "annual"),
+        (local_path("climdexInput.rda"), "ci", "txx", "monthly", "vector_name"),
+        (local_path("climdexInput.rda"), "ci", "txx", "annual", "vector_name"),
+        (local_path("climdexInput.rda"), "ci", "tnx", "monthly", "vector_name"),
+        (local_path("climdexInput.rda"), "ci", "tnx", "annual", "vector_name"),
+        (local_path("climdexInput.rda"), "ci", "txn", "monthly", "vector_name"),
+        (local_path("climdexInput.rda"), "ci", "txn", "annual", "vector_name"),
+        (local_path("climdexInput.rda"), "ci", "tnn", "monthly", "vector_name"),
+        (local_path("climdexInput.rda"), "ci", "tnn", "annual", "vector_name"),
     ],
 )
-def test_wps_climdex_mmdmt(climdex_input, ci_name, month_type, freq):
+def test_wps_climdex_mmdmt(climdex_input, ci_name, month_type, freq, vector_name):
     with NamedTemporaryFile(
         suffix=".rda", prefix="output_", dir="/tmp", delete=True
     ) as out_file:
-        datainputs = (
-            f"climdex_input=@xlink:href={climdex_input};"
-            f"ci_name={ci_name};"
-            f"month_type={month_type};"
-            f"freq={freq};"
-            f"output_file={out_file.name};"
+        datainputs = build_params(
+            climdex_input, ci_name, month_type, freq, vector_name, out_file.name
         )
         run_wps_process(ClimdexMMDMT(), datainputs)
 
 
 @pytest.mark.parametrize(
-    ("climdex_input", "ci_name", "month_type", "freq", "vector_name", "err_type"),
+    ("climdex_input", "ci_name", "month_type", "freq", "vector_name"),
+    [
+        (
+            local_path("climdexInput.rda"),
+            "ci",
+            "txx",
+            "monthly",
+            "vector name",
+        ),
+    ],
+)
+def test_wps_climdex_mmdmt_vector_err(
+    climdex_input, ci_name, month_type, freq, vector_name
+):
+    with NamedTemporaryFile(
+        suffix=".rda", prefix="output_", dir="/tmp", delete=True
+    ) as out_file:
+        datainputs = build_params(
+            climdex_input, ci_name, month_type, freq, vector_name, out_file.name
+        )
+        process_err_test(ClimdexMMDMT, datainputs)
+
+
+@pytest.mark.parametrize(
+    ("climdex_input", "ci_name", "month_type", "freq", "vector_name"),
     [
         (
             local_path("climdexInput.rda"),
@@ -42,15 +72,6 @@ def test_wps_climdex_mmdmt(climdex_input, ci_name, month_type, freq):
             "txx",
             "monthly",
             "vector_name",
-            "unknown ci name",
-        ),
-        (
-            local_path("climdexInput.rda"),
-            "ci",
-            "txx",
-            "monthly",
-            "vector name",
-            "invalid vector name",
         ),
         (
             local_path("expected_mmdmt_data.rda"),
@@ -58,22 +79,16 @@ def test_wps_climdex_mmdmt(climdex_input, ci_name, month_type, freq):
             "tnx",
             "annual",
             "vector_name",
-            "class is not ci",
         ),
     ],
 )
-def test_wps_climdex_mmdmt_err(
-    climdex_input, ci_name, month_type, freq, err_type, vector_name
+def test_wps_climdex_mmdmt_ci_err(
+    climdex_input, ci_name, month_type, freq, vector_name
 ):
     with NamedTemporaryFile(
         suffix=".rda", prefix="output_", dir="/tmp", delete=True
     ) as out_file:
-        datainputs = (
-            f"climdex_input=@xlink:href={climdex_input};"
-            f"ci_name={ci_name};"
-            f"month_type={month_type};"
-            f"vector_name={vector_name};"
-            f"freq={freq};"
-            f"output_file={out_file.name};"
+        datainputs = build_params(
+            climdex_input, ci_name, month_type, freq, vector_name, out_file.name
         )
-        process_err_test(ClimdexMMDMT, datainputs, err_type)
+        process_err_test(ClimdexMMDMT, datainputs)

--- a/tests/test_wps_climdex_quantile.py
+++ b/tests/test_wps_climdex_quantile.py
@@ -1,9 +1,18 @@
 import pytest
 from tempfile import NamedTemporaryFile
 
-from wps_tools.testing import run_wps_process, local_path
+from wps_tools.testing import run_wps_process, local_path, process_err_test
 from quail.processes.wps_climdex_quantile import ClimdexQuantile
-from quail.utils import process_err_test
+
+
+def build_params(data_file, data_vector, quantiles_vector, vector_name, output_file):
+    return (
+        f"data_file=@xlink:href={data_file};"
+        f"data_vector={data_vector};"
+        f"quantiles_vector={quantiles_vector};"
+        f"vector_name={vector_name};"
+        f"output_file={output_file};"
+    )
 
 
 @pytest.mark.parametrize(
@@ -37,47 +46,59 @@ def test_wps_climdex_quantile(
     with NamedTemporaryFile(
         suffix=".rda", prefix="output_", dir="/tmp", delete=True
     ) as out_file:
-        datainputs = (
-            f"data_file=@xlink:href={data_file};"
-            f"data_vector={data_vector};"
-            f"quantiles_vector={quantiles_vector};"
-            f"vector_name={vector_name};"
-            f"output_file={out_file.name};"
+        datainputs = build_params(
+            data_file, data_vector, quantiles_vector, vector_name, out_file.name
         )
-
         run_wps_process(ClimdexQuantile(), datainputs)
 
 
 @pytest.mark.parametrize(
-    ("data_file", "data_vector", "quantiles_vector", "vector_name", "err_type"),
+    ("data_file", "data_vector", "quantiles_vector", "vector_name"),
+    [
+        (
+            local_path("ec.1018935.rda"),
+            "not_tmax",
+            "c(0.1, 0.5, 0.9)",
+            "tmax quantiles",
+        ),
+        (
+            local_path("ec.1018935.rda"),
+            "not_tmax",
+            "c0.1, 0.5, 0.9)",
+            "tmax_quantiles",
+        ),
+    ],
+)
+def test_wps_climdex_quantile_vector_err(
+    data_file, data_vector, quantiles_vector, vector_name
+):
+    with NamedTemporaryFile(
+        suffix=".rda", prefix="output_", dir="/tmp", delete=True
+    ) as out_file:
+        datainputs = build_params(
+            data_file, data_vector, quantiles_vector, vector_name, out_file.name
+        )
+        process_err_test(ClimdexQuantile, datainputs)
+
+
+@pytest.mark.parametrize(
+    ("data_file", "data_vector", "quantiles_vector", "vector_name"),
     [
         (
             local_path("ec.1018935.rda"),
             "not_tmax",
             "c(0.1, 0.5, 0.9)",
             "tmax_quantiles",
-            "load_rda err",
-        ),
-        (
-            local_path("ec.1018935.rda"),
-            "not_tmax",
-            "c(0.1, 0.5, 0.9)",
-            "tmax quantiles",
-            "invalid vector name",
         ),
     ],
 )
-def test_wps_climdex_quantile_err(
-    data_file, data_vector, quantiles_vector, vector_name, err_type
+def test_wps_climdex_quantile_load_rda__err(
+    data_file, data_vector, quantiles_vector, vector_name
 ):
     with NamedTemporaryFile(
         suffix=".rda", prefix="output_", dir="/tmp", delete=True
     ) as out_file:
-        datainputs = (
-            f"data_file=@xlink:href={data_file};"
-            f"data_vector={data_vector};"
-            f"quantiles_vector={quantiles_vector};"
-            f"vector_name={vector_name};"
-            f"output_file={out_file.name};"
+        datainputs = build_params(
+            data_file, data_vector, quantiles_vector, vector_name, out_file.name
         )
-        process_err_test(ClimdexQuantile, datainputs, err_type)
+        process_err_test(ClimdexQuantile, datainputs)

--- a/tests/test_wps_climdex_rxnday.py
+++ b/tests/test_wps_climdex_rxnday.py
@@ -1,52 +1,49 @@
 import pytest
 from tempfile import NamedTemporaryFile
 
-from wps_tools.testing import run_wps_process, local_path
+from wps_tools.testing import run_wps_process, local_path, process_err_test
 from quail.processes.wps_climdex_rxnday import ClimdexRxnday
-from quail.utils import process_err_test
+
+
+def build_params(climdex_input, ci_name, freq, num_days, vector_name, output_file):
+    return (
+        f"climdex_input=@xlink:href={climdex_input};"
+        f"ci_name={ci_name};"
+        f"vector_name={vector_name}"
+        f"freq={freq};"
+        f"num_days={num_days};"
+        f"output_file={output_file};"
+    )
 
 
 @pytest.mark.parametrize(
-    ("climdex_input", "ci_name", "freq", "num_days"),
+    ("climdex_input", "ci_name", "freq", "num_days", "vector_name"),
     [
-        (local_path("climdexInput.rda"), "ci", "monthly", 1),
-        (local_path("climdexInput.rda"), "ci", "annual", 1),
-        (local_path("climdexInput.rda"), "ci", "monthly", 5),
-        (local_path("climdexInput.rda"), "ci", "annual", 5),
+        (local_path("climdexInput.rda"), "ci", "monthly", 1, "vector_name"),
+        (local_path("climdexInput.rda"), "ci", "annual", 1, "vector_name"),
+        (local_path("climdexInput.rda"), "ci", "monthly", 5, "vector_name"),
+        (local_path("climdexInput.rda"), "ci", "annual", 5, "vector_name"),
     ],
 )
-def test_wps_climdex_rxnday(climdex_input, ci_name, freq, num_days):
+def test_wps_climdex_rxnday(climdex_input, ci_name, freq, num_days, vector_name):
     with NamedTemporaryFile(
         suffix=".rda", prefix="output_", dir="/tmp", delete=True
     ) as out_file:
-        datainputs = (
-            f"climdex_input=@xlink:href={climdex_input};"
-            f"ci_name={ci_name};"
-            f"freq={freq};"
-            f"num_days={num_days};"
-            f"output_file={out_file.name};"
+        datainputs = build_params(
+            climdex_input, ci_name, freq, num_days, vector_name, out_file.name
         )
         run_wps_process(ClimdexRxnday(), datainputs)
 
 
 @pytest.mark.parametrize(
-    ("climdex_input", "ci_name", "freq", "num_days", "vector_name", "err_type"),
+    ("climdex_input", "ci_name", "freq", "num_days", "vector_name"),
     [
-        (
-            local_path("climdexInput.rda"),
-            "ci",
-            "monthly",
-            1,
-            "vector name",
-            "invalid vector name",
-        ),
         (
             local_path("climdexInput.rda"),
             "not_ci",
             "monthly",
             1,
             "vector_name",
-            "unknown ci name",
         ),
         (
             local_path("expected_rxnday.rda"),
@@ -54,22 +51,14 @@ def test_wps_climdex_rxnday(climdex_input, ci_name, freq, num_days):
             "annual",
             5,
             "vector_name",
-            "class is not ci",
         ),
     ],
 )
-def test_wps_climdex_rxnday_err(
-    climdex_input, ci_name, freq, num_days, vector_name, err_type
-):
+def test_wps_climdex_rxnday_ci_err(climdex_input, ci_name, freq, num_days, vector_name):
     with NamedTemporaryFile(
         suffix=".rda", prefix="output_", dir="/tmp", delete=True
     ) as out_file:
-        datainputs = (
-            f"climdex_input=@xlink:href={climdex_input};"
-            f"ci_name={ci_name};"
-            f"freq={freq};"
-            f"vector_name={vector_name};"
-            f"num_days={num_days};"
-            f"output_file={out_file.name};"
+        datainputs = build_params(
+            climdex_input, ci_name, freq, num_days, vector_name, out_file.name
         )
-        process_err_test(ClimdexRxnday, datainputs, err_type)
+        process_err_test(ClimdexRxnday, datainputs)

--- a/tests/test_wps_climdex_sdii.py
+++ b/tests/test_wps_climdex_sdii.py
@@ -1,55 +1,69 @@
 import pytest
 from tempfile import NamedTemporaryFile
 
-from wps_tools.testing import run_wps_process, local_path
+from wps_tools.testing import run_wps_process, local_path, process_err_test
 from quail.processes.wps_climdex_sdii import ClimdexSDII
-from quail.utils import process_err_test
+
+
+def build_params(climdex_input, ci_name, vector_name, output_file):
+    return (
+        f"climdex_input=@xlink:href={climdex_input};"
+        f"ci_name={ci_name};"
+        f"vector_name={vector_name};"
+        f"output_file={output_file};"
+    )
 
 
 @pytest.mark.parametrize(
-    ("climdex_input", "ci_name"),
+    ("climdex_input", "ci_name", "vector_name"),
     [
-        (local_path("climdexInput.rda"), "ci"),
+        (local_path("climdexInput.rda"), "ci", "vector_name"),
     ],
 )
-def test_wps_climdex_sdii(climdex_input, ci_name):
+def test_wps_climdex_sdii(climdex_input, ci_name, vector_name):
     with NamedTemporaryFile(
         suffix=".rda", prefix="output_", dir="/tmp", delete=True
     ) as out_file:
-        datainputs = (
-            f"climdex_input=@xlink:href={climdex_input};"
-            f"ci_name={ci_name};"
-            f"output_file={out_file.name};"
-        )
+        datainputs = build_params(climdex_input, ci_name, vector_name, out_file.name)
         run_wps_process(ClimdexSDII(), datainputs)
 
 
 @pytest.mark.parametrize(
-    ("climdex_input", "ci_name", "vector_name", "err_type"),
+    ("climdex_input", "ci_name", "vector_name"),
     [
-        (local_path("climdexInput.rda"), "not_ci", "vector_name", "unknown ci name"),
+        (
+            local_path("climdexInput.rda"),
+            "ci",
+            "vector name",
+        ),
+    ],
+)
+def test_wps_climdex_sdii_vector_err(climdex_input, ci_name, vector_name):
+    with NamedTemporaryFile(
+        suffix=".rda", prefix="output_", dir="/tmp", delete=True
+    ) as out_file:
+        datainputs = build_params(climdex_input, ci_name, vector_name, out_file.name)
+        process_err_test(ClimdexSDII, datainputs)
+
+
+@pytest.mark.parametrize(
+    ("climdex_input", "ci_name", "vector_name"),
+    [
         (
             local_path("climdexInput.rda"),
             "not_ci",
-            "vector name",
-            "invalid vector name",
+            "vector_name",
         ),
         (
             local_path("expected_sdii.rda"),
             "expected_sdii",
             "vector_name",
-            "class is not ci",
         ),
     ],
 )
-def test_wps_climdex_sdii_err(climdex_input, ci_name, err_type, vector_name):
+def test_wps_climdex_sdii_ci_err(climdex_input, ci_name, vector_name):
     with NamedTemporaryFile(
         suffix=".rda", prefix="output_", dir="/tmp", delete=True
     ) as out_file:
-        datainputs = (
-            f"climdex_input=@xlink:href={climdex_input};"
-            f"ci_name={ci_name};"
-            f"vector_name={vector_name};"
-            f"output_file={out_file.name};"
-        )
-        process_err_test(ClimdexSDII, datainputs, err_type)
+        datainputs = build_params(climdex_input, ci_name, vector_name, out_file.name)
+        process_err_test(ClimdexSDII, datainputs)

--- a/tests/test_wps_climdex_spells.py
+++ b/tests/test_wps_climdex_spells.py
@@ -1,40 +1,46 @@
 import pytest
 from tempfile import NamedTemporaryFile
 
-from wps_tools.testing import run_wps_process, local_path
+from wps_tools.testing import run_wps_process, local_path, process_err_test
 from quail.processes.wps_climdex_spells import ClimdexSpells
-from quail.utils import process_err_test
+
+
+def build_params(climdex_input, ci_name, func, span_years, vector_name, output_file):
+    return (
+        f"climdex_input=@xlink:href={climdex_input};"
+        f"ci_name={ci_name};"
+        f"func={func};"
+        f"span_years={span_years};"
+        f"vector_name={vector_name};"
+        f"output_file={output_file};"
+    )
 
 
 @pytest.mark.parametrize(
-    ("climdex_input", "ci_name", "func", "span_years"),
+    ("climdex_input", "ci_name", "func", "span_years", "vector_name"),
     [
-        (local_path("climdexInput.rda"), "ci", "wsdi", False),
-        (local_path("climdexInput.rda"), "ci", "wsdi", True),
-        (local_path("climdexInput.rda"), "ci", "csdi", False),
-        (local_path("climdexInput.rda"), "ci", "csdi", True),
-        (local_path("climdexInput.rda"), "ci", "cdd", False),
-        (local_path("climdexInput.rda"), "ci", "cdd", True),
-        (local_path("climdexInput.rda"), "ci", "cwd", False),
-        (local_path("climdexInput.rda"), "ci", "cwd", True),
+        (local_path("climdexInput.rda"), "ci", "wsdi", False, "vector_name"),
+        (local_path("climdexInput.rda"), "ci", "wsdi", True, "vector_name"),
+        (local_path("climdexInput.rda"), "ci", "csdi", False, "vector_name"),
+        (local_path("climdexInput.rda"), "ci", "csdi", True, "vector_name"),
+        (local_path("climdexInput.rda"), "ci", "cdd", False, "vector_name"),
+        (local_path("climdexInput.rda"), "ci", "cdd", True, "vector_name"),
+        (local_path("climdexInput.rda"), "ci", "cwd", False, "vector_name"),
+        (local_path("climdexInput.rda"), "ci", "cwd", True, "vector_name"),
     ],
 )
-def test_wps_climdex_spells(climdex_input, ci_name, func, span_years):
+def test_wps_climdex_spells(climdex_input, ci_name, func, span_years, vector_name):
     with NamedTemporaryFile(
         suffix=".rda", prefix="output_", dir="/tmp", delete=True
     ) as out_file:
-        datainputs = (
-            f"climdex_input=@xlink:href={climdex_input};"
-            f"ci_name={ci_name};"
-            f"func={func};"
-            f"span_years={span_years};"
-            f"output_file={out_file.name};"
+        datainputs = build_params(
+            climdex_input, ci_name, func, span_years, vector_name, out_file.name
         )
         run_wps_process(ClimdexSpells(), datainputs)
 
 
 @pytest.mark.parametrize(
-    ("climdex_input", "ci_name", "func", "span_years", "vector_name", "err_type"),
+    ("climdex_input", "ci_name", "func", "span_years", "vector_name"),
     [
         (
             local_path("climdexInput.rda"),
@@ -42,15 +48,30 @@ def test_wps_climdex_spells(climdex_input, ci_name, func, span_years):
             "wsdi",
             False,
             "vector name",
-            "invalid vector name",
         ),
+    ],
+)
+def test_wps_climdex_spells_vector_err(
+    climdex_input, ci_name, func, span_years, vector_name
+):
+    with NamedTemporaryFile(
+        suffix=".rda", prefix="output_", dir="/tmp", delete=True
+    ) as out_file:
+        datainputs = build_params(
+            climdex_input, ci_name, func, span_years, vector_name, out_file.name
+        )
+        process_err_test(ClimdexSpells, datainputs)
+
+
+@pytest.mark.parametrize(
+    ("climdex_input", "ci_name", "func", "span_years", "vector_name"),
+    [
         (
             local_path("climdexInput.rda"),
             "not_ci",
             "wsdi",
             False,
             "vector_name",
-            "unknown ci name",
         ),
         (
             local_path("expected_spells_data.rda"),
@@ -58,22 +79,16 @@ def test_wps_climdex_spells(climdex_input, ci_name, func, span_years):
             "csdi",
             True,
             "vector_name",
-            "class is not ci",
         ),
     ],
 )
-def test_wps_climdex_spells_err(
-    climdex_input, ci_name, func, span_years, err_type, vector_name
+def test_wps_climdex_spells_ci_err(
+    climdex_input, ci_name, func, span_years, vector_name
 ):
     with NamedTemporaryFile(
         suffix=".rda", prefix="output_", dir="/tmp", delete=True
     ) as out_file:
-        datainputs = (
-            f"climdex_input=@xlink:href={climdex_input};"
-            f"ci_name={ci_name};"
-            f"func={func};"
-            f"span_years={span_years};"
-            f"vector_name={vector_name};"
-            f"output_file={out_file.name};"
+        datainputs = build_params(
+            climdex_input, ci_name, func, span_years, vector_name, out_file.name
         )
-        process_err_test(ClimdexSpells, datainputs, err_type)
+        process_err_test(ClimdexSpells, datainputs)

--- a/tests/test_wps_climdex_temp_pctl.py
+++ b/tests/test_wps_climdex_temp_pctl.py
@@ -1,25 +1,35 @@
 import pytest
 from tempfile import NamedTemporaryFile
 
-from wps_tools.testing import run_wps_process, local_path
+from wps_tools.testing import run_wps_process, local_path, process_err_test
 from quail.processes.wps_climdex_temp_pctl import ClimdexTempPctl
-from quail.utils import process_err_test
+
+
+def build_params(climdex_input, ci_name, func, freq, vector_name, output_file):
+    return (
+        f"climdex_input=@xlink:href={climdex_input};"
+        f"ci_name={ci_name};"
+        f"func={func};"
+        f"freq={freq};"
+        f"vector_name={vector_name};"
+        f"output_file={output_file};"
+    )
 
 
 @pytest.mark.parametrize(
-    ("climdex_input", "ci_name", "func", "freq"),
+    ("climdex_input", "ci_name", "func", "freq", "vector_name"),
     [
-        (local_path("climdexInput.rda"), "ci", "tn10p", "monthly"),
-        (local_path("climdexInput.rda"), "ci", "tn10p", "annual"),
-        (local_path("climdexInput.rda"), "ci", "tn90p", "monthly"),
-        (local_path("climdexInput.rda"), "ci", "tn90p", "annual"),
-        (local_path("climdexInput.rda"), "ci", "tx10p", "monthly"),
-        (local_path("climdexInput.rda"), "ci", "tx10p", "annual"),
-        (local_path("climdexInput.rda"), "ci", "tx90p", "monthly"),
-        (local_path("climdexInput.rda"), "ci", "tx90p", "annual"),
+        (local_path("climdexInput.rda"), "ci", "tn10p", "monthly", "vector_name"),
+        (local_path("climdexInput.rda"), "ci", "tn10p", "annual", "vector_name"),
+        (local_path("climdexInput.rda"), "ci", "tn90p", "monthly", "vector_name"),
+        (local_path("climdexInput.rda"), "ci", "tn90p", "annual", "vector_name"),
+        (local_path("climdexInput.rda"), "ci", "tx10p", "monthly", "vector_name"),
+        (local_path("climdexInput.rda"), "ci", "tx10p", "annual", "vector_name"),
+        (local_path("climdexInput.rda"), "ci", "tx90p", "monthly", "vector_name"),
+        (local_path("climdexInput.rda"), "ci", "tx90p", "annual", "vector_name"),
     ],
 )
-def test_wps_climdex_temp_pctl(climdex_input, ci_name, func, freq):
+def test_wps_climdex_temp_pctl(climdex_input, ci_name, func, freq, vector_name):
     with NamedTemporaryFile(
         suffix=".rda", prefix="output_", dir="/tmp", delete=True
     ) as out_file:
@@ -34,7 +44,31 @@ def test_wps_climdex_temp_pctl(climdex_input, ci_name, func, freq):
 
 
 @pytest.mark.parametrize(
-    ("climdex_input", "ci_name", "func", "freq", "vector_name", "err_type"),
+    ("climdex_input", "ci_name", "func", "freq", "vector_name"),
+    [
+        (
+            local_path("climdexInput.rda"),
+            "ci",
+            "tn10p",
+            "monthly",
+            "vector name",
+        ),
+    ],
+)
+def test_wps_climdex_temp_pctl_vector_err(
+    climdex_input, ci_name, func, freq, vector_name
+):
+    with NamedTemporaryFile(
+        suffix=".rda", prefix="output_", dir="/tmp", delete=True
+    ) as out_file:
+        datainputs = build_params(
+            climdex_input, ci_name, func, freq, vector_name, out_file.name
+        )
+        process_err_test(ClimdexTempPctl, datainputs)
+
+
+@pytest.mark.parametrize(
+    ("climdex_input", "ci_name", "func", "freq", "vector_name"),
     [
         (
             local_path("climdexInput.rda"),
@@ -42,15 +76,6 @@ def test_wps_climdex_temp_pctl(climdex_input, ci_name, func, freq):
             "tn10p",
             "monthly",
             "vector_name",
-            "unknown ci name",
-        ),
-        (
-            local_path("climdexInput.rda"),
-            "ci",
-            "tn10p",
-            "monthly",
-            "vector name",
-            "invalid vector name",
         ),
         (
             local_path("expected_temp_pctl.rda"),
@@ -58,22 +83,14 @@ def test_wps_climdex_temp_pctl(climdex_input, ci_name, func, freq):
             "tn90p",
             "annual",
             "vector_name",
-            "class is not ci",
         ),
     ],
 )
-def test_wps_climdex_temp_pctl_err(
-    climdex_input, ci_name, func, freq, err_type, vector_name
-):
+def test_wps_climdex_temp_pctl_ci_err(climdex_input, ci_name, func, freq, vector_name):
     with NamedTemporaryFile(
         suffix=".rda", prefix="output_", dir="/tmp", delete=True
     ) as out_file:
-        datainputs = (
-            f"climdex_input=@xlink:href={climdex_input};"
-            f"ci_name={ci_name};"
-            f"func={func};"
-            f"freq={freq};"
-            f"vector_name={vector_name};"
-            f"output_file={out_file.name};"
+        datainputs = build_params(
+            climdex_input, ci_name, func, freq, vector_name, out_file.name
         )
-        process_err_test(ClimdexTempPctl, datainputs, err_type)
+        process_err_test(ClimdexTempPctl, datainputs)


### PR DESCRIPTION
- Imports `r_valid_name` and `process_error_test` from `wps-tools` 
- Adds `build_params` to most process tests
- Fixes some utils tests that weren't reaching the assert statements (nothing is run below first function call in the `with pytest.raises(Exception)` block)

You can test on port `30874`